### PR TITLE
chore: add fs-extra as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "@octokit/plugin-throttling": "^2.4.0",
     "@octokit/rest": "^16.25.1",
     "chalk": "^2.4.2",
+    "fs-extra": "^10.0.0",
     "js-base64": "^2.5.1",
     "npm-registry-fetch": "^3.9.0",
     "semver": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3689,6 +3689,15 @@ fs-exists-sync@^0.1.0:
   resolved "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
   integrity sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=
 
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"


### PR DESCRIPTION
`fs-extra` is used in `getConfig.js`, so it should be a direct dependency.

I got this error:

```
Error: Cannot find module 'fs-extra'
```