### PR TITLE
Add additional GitHub release tag format fallbacks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,7 @@ export async function fetchChangelog(
             version,
             `${pkg}@${version}`,
             `${pkg}@v${version}`,
+            `${pkg}: v${version}`,
           ]
 
           let body: string | undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,20 +195,27 @@ export async function fetchChangelog(
         const { owner, repo } = parseRepositoryUrl(url)
 
         try {
-          const body =
-            (
-              await doOctokit('repos', 'getReleaseByTag', {
+          const tagFormats = [
+            `v${version}`,
+            version,
+            `${pkg}@${version}`,
+            `${pkg}@v${version}`,
+          ]
+
+          let body: string | undefined
+          for (const tag of tagFormats) {
+            try {
+              const result = await doOctokit('repos', 'getReleaseByTag', {
                 owner,
                 repo,
-                tag: `v${version}`,
-              }).catch(() => {
-                return doOctokit('repos', 'getReleaseByTag', {
-                  owner,
-                  repo,
-                  tag: version,
-                })
+                tag,
               })
-            ).data.body ?? undefined
+              body = result.data.body ?? undefined
+              break
+            } catch {
+              continue
+            }
+          }
 
           release.body = body
 


### PR DESCRIPTION
This PR adds support for additional GitHub release tag formats and refactors the tag lookup logic for better maintainability.

## Changes
- Add support for `package@version` tag format (e.g., `my-package@1.0.0`)
- Add support for `package@vversion` tag format (e.g., `my-package@v1.0.0`)
- Add support for `package: vversion` tag format (e.g., `puppeteer: v24.29.0`)
- Refactor tag lookup from nested catch handlers to an array-based approach

## Tag Format Priority
The code now tries tag formats in the following order:
1. `v${version}` (e.g., `v1.0.0`)
2. `version` (e.g., `1.0.0`)
3. `${pkg}@${version}` (e.g., `my-package@1.0.0`, `@tanstack/react-query@5.90.8`)
4. `${pkg}@v${version}` (e.g., `my-package@v1.0.0`, `@ai-sdk/vue@v2.0.93`)
5. `${pkg}: v${version}` (e.g., `puppeteer: v24.29.0`)

## Examples
- TanStack Query: https://github.com/TanStack/query/releases - uses `@tanstack/react-query@5.90.8`
- Vercel AI SDK: https://github.com/vercel/ai/releases/tag/%40ai-sdk%2Fvue%402.0.93 - uses `@ai-sdk/vue@2.0.93`
- Puppeteer: uses `puppeteer: v24.29.0`

This makes the code more maintainable and easier to extend with additional tag formats in the future.